### PR TITLE
fix: deferred LogOnError never logs

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -17,14 +17,14 @@ func OnError(err *error, format string, args ...interface{}) {
 }
 
 // LogOnError logs only any errors without failing.
-func LogOnError(err error) {
+func LogOnError(err *error) {
 	LogOnErrorContext(context.Background(), err)
 }
 
 // LogOnErrorContext logs any errors without failing. It takes a context.
-func LogOnErrorContext(ctx context.Context, err error) {
-	if err != nil {
-		log.Warning(ctx, err)
+func LogOnErrorContext(ctx context.Context, err *error) {
+	if *err != nil {
+		log.Warning(ctx, *err)
 	}
 }
 

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -39,7 +39,7 @@ func TestLogOnErrorWithNoError(t *testing.T) {
 	out := captureLogs(t)
 
 	_ = func() (err error) {
-		defer decorate.LogOnError(err)
+		defer decorate.LogOnError(&err)
 		return nil
 	}()
 
@@ -50,7 +50,7 @@ func TestLogOnErrorWithError(t *testing.T) {
 	out := captureLogs(t)
 
 	err := func() (err error) {
-		defer decorate.LogOnError(err)
+		defer decorate.LogOnError(&err)
 		return errors.New("Some error")
 	}()
 
@@ -61,7 +61,7 @@ func TestLogOnErrorContextWithNoError(t *testing.T) {
 	out := captureLogs(t)
 
 	_ = func() (err error) {
-		defer decorate.LogOnErrorContext(context.Background(), err)
+		defer decorate.LogOnErrorContext(context.Background(), &err)
 		return nil
 	}
 
@@ -72,7 +72,7 @@ func TestLogOnErrorContextWithError(t *testing.T) {
 	out := captureLogs(t)
 
 	err := func() (err error) {
-		defer decorate.LogOnErrorContext(context.Background(), err)
+		defer decorate.LogOnErrorContext(context.Background(), &err)
 		return errors.New("Some error")
 	}()
 

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -15,23 +15,33 @@ import (
 
 func TestOnErrorWithNoError(t *testing.T) {
 	t.Parallel()
-	var err error
-	decorate.OnError(&err, "My format with %s as argument", "arg")
+
+	err := func() (err error) {
+		defer decorate.OnError(&err, "My format with %s as argument", "arg")
+		return nil
+	}()
+
 	require.NoError(t, err, "No decoration as no error")
 }
 
 func TestOnErrorWithError(t *testing.T) {
 	t.Parallel()
-	err := errors.New("Some error")
-	decorate.OnError(&err, "My format with %s as argument", "arg")
+
+	err := func() (err error) {
+		defer decorate.OnError(&err, "My format with %s as argument", "arg")
+		return errors.New("Some error")
+	}()
+
 	require.Equal(t, errors.New("My format with arg as argument: Some error").Error(), err.Error(), "Should annotate with error format")
 }
 
 func TestLogOnErrorWithNoError(t *testing.T) {
 	out := captureLogs(t)
 
-	var err error
-	decorate.LogOnError(err)
+	_ = func() (err error) {
+		defer decorate.LogOnError(err)
+		return nil
+	}()
 
 	require.Empty(t, out(), "No error  no log")
 }
@@ -39,8 +49,10 @@ func TestLogOnErrorWithNoError(t *testing.T) {
 func TestLogOnErrorWithError(t *testing.T) {
 	out := captureLogs(t)
 
-	err := errors.New("Some error")
-	decorate.LogOnError(err)
+	err := func() (err error) {
+		defer decorate.LogOnError(err)
+		return errors.New("Some error")
+	}()
 
 	require.Contains(t, out(), err.Error(), "The error should be logged")
 }
@@ -48,8 +60,10 @@ func TestLogOnErrorWithError(t *testing.T) {
 func TestLogOnErrorContextWithNoError(t *testing.T) {
 	out := captureLogs(t)
 
-	var err error
-	decorate.LogOnErrorContext(context.Background(), err)
+	_ = func() (err error) {
+		defer decorate.LogOnErrorContext(context.Background(), err)
+		return nil
+	}
 
 	require.Empty(t, out(), "No error  no log")
 }
@@ -57,8 +71,10 @@ func TestLogOnErrorContextWithNoError(t *testing.T) {
 func TestLogOnErrorContextWithError(t *testing.T) {
 	out := captureLogs(t)
 
-	err := errors.New("Some error")
-	decorate.LogOnErrorContext(context.Background(), err)
+	err := func() (err error) {
+		defer decorate.LogOnErrorContext(context.Background(), err)
+		return errors.New("Some error")
+	}()
 
 	require.Contains(t, out(), err.Error(), "The error should be logged")
 }
@@ -69,7 +85,7 @@ func TestLogFuncOnErrorWithNoError(t *testing.T) {
 	f := func() error { return nil }
 	decorate.LogFuncOnError(f)
 
-	require.Empty(t, out(), "No error  no log")
+	require.Empty(t, out(), "No error no log")
 }
 
 func TestLogFuncOnErrorWithError(t *testing.T) {


### PR DESCRIPTION
Found a bug in LogOnError: it captures the error at the time defer is called, and not during the return. This means that it'll never log.

This problem managed to sneak through the cracks because the tests are not run in the same way as production code. In production, you always defer the decorate statements. Hence, the fist commit refactors the tests to use `defer`, and the second commit fixes the issue (**THIS BREAKS API**).

As an example, this code will never log:
```go
func isEven(x int) (err error) {
    defer decorate.LogOnError(err)
    
    if x == 0 {
       return true
    } else if x == 1 {
       return false
    } else if x == 2 {
       return true
    } else if x == 3 {
       return false
    } else if x == 4 {
       return true
    } else if x == 5 {
       return false
    }

    return errors.New("number too big")
}
```

