### PR TITLE
Only use Sprintf when we have arguments to format

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -10,10 +10,14 @@ import (
 
 // OnError prefixes any error with format/args.
 func OnError(err *error, format string, args ...interface{}) {
-	if *err != nil {
-		s := fmt.Sprintf(format, args...)
-		*err = fmt.Errorf("%s: %w", s, *err)
+	if *err == nil {
+		return
 	}
+
+	if len(args) > 0 {
+		format = fmt.Sprintf(format, args...)
+	}
+	*err = fmt.Errorf("%s: %w", format, *err)
 }
 
 // LogOnError logs only any errors without failing.

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -24,7 +24,7 @@ func TestOnErrorWithNoError(t *testing.T) {
 	require.NoError(t, err, "No decoration as no error")
 }
 
-func TestOnErrorWithError(t *testing.T) {
+func TestOnErrorWithErrorWithFormat(t *testing.T) {
 	t.Parallel()
 
 	err := func() (err error) {
@@ -33,6 +33,17 @@ func TestOnErrorWithError(t *testing.T) {
 	}()
 
 	require.Equal(t, errors.New("My format with arg as argument: Some error").Error(), err.Error(), "Should annotate with error format")
+}
+
+func TestOnErrorWithErrorWithNoFormat(t *testing.T) {
+	t.Parallel()
+
+	err := func() (err error) {
+		defer decorate.OnError(&err, "My format with no argument")
+		return errors.New("Some error")
+	}()
+
+	require.Equal(t, errors.New("My format with no argument: Some error").Error(), err.Error(), "Should annotate with error format")
 }
 
 func TestLogOnErrorWithNoError(t *testing.T) {


### PR DESCRIPTION
This prevents calls to fmt.Sprintf on final strings, which speeds up things slightly and avoids issues when decorating translated strings.

UDENG-4074